### PR TITLE
misc/improve_eslint_type_checking

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,6 +41,7 @@
     ],
     "class-methods-use-this": [1],
     "no-underscore-dangle": [0],
+    "no-use-before-define": "off",
     "@typescript-eslint/no-unused-vars": [
       2,
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,6 +42,7 @@
     "class-methods-use-this": [1],
     "no-underscore-dangle": [0],
     "no-use-before-define": "off",
+    "@typescript-eslint/no-use-before-define": ["error"],
     "@typescript-eslint/no-unused-vars": [
       2,
       {


### PR DESCRIPTION
Change note:
- Base on official docs in [here](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-use-before-define.md#how-to-use), we need disable default eslint rule to fix incorret error.
![img](https://i.imgur.com/e4weT1V.png)